### PR TITLE
Fix configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ groups that were modified by the command.
 
 ## Configuration
 
-You can configure poetry-sort via the `tool.poetry.sort` section of `pyproject.toml`.
+You can configure poetry-sort via the `tool.poetry-sort` section of `pyproject.toml`.
 
 ```toml
-[tool.sort.config]
+[tool.poetry-sort]
 auto = true
 case-sensitive = false
 sort-python = false


### PR DESCRIPTION
Looks like in the 2.0 release, the configuration path was changed from `tool.poetry.sort` to `tool.poetry-sort`. Got stuck for a bit because the readme shows `tool.sort.config` as well as `tool.poetry.sort`.  Just a quick update to make it match what's currently the config path